### PR TITLE
Show repo name on all lines

### DIFF
--- a/simple-event-logger.js
+++ b/simple-event-logger.js
@@ -61,12 +61,8 @@ function(event, encoding, cb) {
          break;
    }
 
-   date = date.calendar() + " - ";
-   if (l) {
-      this.push(date + l.join(" ") + "\n");
-   } else {
-      this.push(date + event.repo.name + ": " + event.type + "\n");
-   }
+   var message = l ? l.join(" ") : event.type;
+   this.push(date.calendar() + " - " + event.repo.name + ": " + message + "\n");
    cb();
 };
 


### PR DESCRIPTION
`Yesterday at 6:17 PM - Pushed 5 commits to master` isn't that useful if you work on multiple projects. Now it looks like
`Last Wednesday at 4:11 PM - iFixit/ifixit: Pushed 2 commits to master`

Closes #2 